### PR TITLE
Expanding `dep` to `dep()` in `mix.exs`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule MixCtags.Mixfile do
     [app: :mix_ctags,
      version: "0.0.1",
      elixir: "~> 1.0",
-     deps: deps]
+     deps: deps()]
   end
 
   defp deps do


### PR DESCRIPTION
Expanding `dep` prevents the application to issue warnings like the one bellow:

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  */your_app/deps/mix_ctags/mix.exs:8
```