### PR TITLE
Elixir 1.14 readiness

### DIFF
--- a/lib/mix/tasks/ctags.ex
+++ b/lib/mix/tasks/ctags.ex
@@ -12,10 +12,12 @@ defmodule Mix.Tasks.Ctags do
   end
 
   @shortdoc "Generate ctags for the project"
-  def run(args) do
-    case Enum.find(possible_paths, &File.exists?/1) do
-      nil -> IO.puts "Cannot find ctags_ex in #{possible_paths}"
-      p -> p |> ctags_command |> Mix.Shell.IO.cmd
+  def run(_args) do
+    possible_paths()
+    |> Enum.find(&File.exists?/1)
+    |> case() do
+      nil -> IO.puts("Cannot find ctags_ex in #{possible_paths()}")
+      p -> p |> ctags_command() |> Mix.Shell.IO.cmd()
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule MixCtags.Mixfile do
     [app: :mix_ctags,
      version: "0.0.1",
      elixir: "~> 1.0",
-     deps: deps]
+     deps: deps()]
   end
 
   defp deps do


### PR DESCRIPTION
Fixes a few paren-less function calls - formerly a harmless stylistic choice, now a compiler error.